### PR TITLE
Issue: Manga links are able to open in Animiru

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # ![app icon](.github/readme-images/app-icon.png)Animiru
 Animiru is an unofficial fork of [Aniyomi](https://github.com/jmir1/aniyomi), which is yet another unofficial fork of the free and open source manga reader [Tachiyomi](https://github.com/tachiyomiorg/tachiyomi)
 
-Animiru strips the manga capabilities of Aniyomi, to make it an anime only app for Android 6.0+
+Animiru strips the manga capabilities of Aniyomi, to make it an anime only app for Android 6.0+ 
 
 
 ## Features


### PR DESCRIPTION
Android app selection interface for link opening shows Animiru as a choice when opening manga links. This should be removed.

Animiru version: 0.13.2.4
Android 12

![](https://i.imgur.com/spQafLi.png)

PS: don't merge this PR. Issues are not enabled on this repo so I had to create a PR.
<sub>BTW thanks for creating what Aniyomi should have been.</sub>
