### PR TITLE
Add parent title to user-data in lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Added
+- Add parent title to user-data in lua ([@Secozzi](https://github.com/Secozzi)) ([#142](https://github.com/quickdesh/Animiru/pull/142))
+
 ### Fixed
 - Fix "Override ASS/SSA subtitles" option ([@Secozzi](https://github.com/Secozzi)) ([#141](https://github.com/quickdesh/Animiru/pull/141))
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -1277,7 +1277,9 @@ class PlayerViewModel @JvmOverloads constructor(
                 _hasNextEpisode.update { _ -> getCurrentEpisodeIndex() != currentPlaylist.value.size - 1 }
 
                 // Write to mpv table
+                val parentTitle = anime.parentId?.let { getAnime.await(it)?.title } ?: ""
                 mpv.setPropertyString("user-data/current-anime/anime-title", anime.title)
+                mpv.setPropertyString("user-data/current-anime/parent-title", parentTitle)
                 mpv.setPropertyInt("user-data/current-anime/intro-length", getAnimeSkipIntroLength())
                 mpv.setPropertyString(
                     "user-data/current-anime/category",


### PR DESCRIPTION
A lot of series with seasons will have the series name and "Season 1", "Season 2" etc for the season names, so trying to use the "anime-title" property in user-data doesn't really work for these cases.