### PR TITLE
Copy over mpv files on app resume

### DIFF
--- a/app/src/main/java/animiru/feature/mpvfiles/MpvConfig.kt
+++ b/app/src/main/java/animiru/feature/mpvfiles/MpvConfig.kt
@@ -1,0 +1,139 @@
+package animiru.feature.mpvfiles
+
+import android.content.Context
+import android.content.res.AssetManager
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.ui.player.settings.AdvancedPlayerPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.storage.service.StorageManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+
+class MpvConfig(
+    private val context: Context,
+    private val storageManager: StorageManager = Injekt.get(),
+    private val advancedPlayerPreferences: AdvancedPlayerPreferences = Injekt.get(),
+) {
+    private val scope = CoroutineScope(Dispatchers.IO)
+    private var copyJob: Job? = null
+
+    fun copyFiles() {
+        if (copyJob?.isActive == true) return
+
+        copyJob = scope.launchIO {
+            val mpvDir = UniFile.fromFile(context.filesDir)!!.createDirectory(MPV_DIR)!!
+            copyUserFiles(mpvDir)
+            copyFontsDirectory(mpvDir)
+            copyAssets(mpvDir)
+        }
+    }
+
+    private suspend fun copyUserFiles(mpvDir: UniFile) {
+        // First, delete all present scripts
+        val scriptsDir = { mpvDir.createDirectory(MPV_SCRIPTS_DIR) }
+        val scriptOptsDir = { mpvDir.createDirectory(MPV_SCRIPTS_OPTS_DIR) }
+        val shadersDir = { mpvDir.createDirectory(MPV_SHADERS_DIR) }
+
+        scriptsDir()?.delete()
+        scriptOptsDir()?.delete()
+        shadersDir()?.delete()
+
+        // Then, copy the user files from the Aniyomi directory
+        if (advancedPlayerPreferences.mpvUserFiles.get()) {
+            storageManager.getScriptsDirectory()?.listFiles()?.forEach { file ->
+                ensureActive()
+                val outFile = scriptsDir()?.createFile(file.name)
+                outFile?.let {
+                    file.openInputStream().copyTo(it.openOutputStream())
+                }
+            }
+            storageManager.getScriptOptsDirectory()?.listFiles()?.forEach { file ->
+                ensureActive()
+                val outFile = scriptOptsDir()?.createFile(file.name)
+                outFile?.let {
+                    file.openInputStream().copyTo(it.openOutputStream())
+                }
+            }
+            storageManager.getShadersDirectory()?.listFiles()?.forEach { file ->
+                ensureActive()
+                val outFile = shadersDir()?.createFile(file.name)
+                outFile?.let {
+                    file.openInputStream().copyTo(it.openOutputStream())
+                }
+            }
+        }
+
+        // Copy over the bridge file
+        val luaFile = scriptsDir()?.createFile("aniyomi.lua")
+        val luaBridge = context.assets.open("aniyomi.lua")
+        luaFile?.openOutputStream()?.bufferedWriter()?.use { scriptLua ->
+            luaBridge.bufferedReader().use { scriptLua.write(it.readText()) }
+        }
+    }
+
+    private suspend fun copyFontsDirectory(mpvDir: UniFile) {
+        // TODO: I think this is a bad hack.
+        //  We need to find a way to let MPV directly access our fonts directory.
+        val fontsDirectory = mpvDir.createDirectory(MPV_FONTS_DIR)!!
+
+        storageManager.getFontsDirectory()?.listFiles()?.forEach { font ->
+            ensureActive()
+            val outFile = fontsDirectory.createFile(font.name)
+            outFile?.let {
+                font.openInputStream().copyTo(it.openOutputStream())
+            }
+        }
+    }
+
+    private fun copyAssets(mpvDir: UniFile) {
+        val assetManager = context.assets
+        val files = arrayOf("subfont.ttf", "cacert.pem")
+        for (filename in files) {
+            var ins: InputStream? = null
+            var out: OutputStream? = null
+            try {
+                ins = assetManager.open(filename, AssetManager.ACCESS_STREAMING)
+                val outFile = mpvDir.createFile(filename)!!
+                // Note that .available() officially returns an *estimated* number of bytes available
+                // this is only true for generic streams, asset streams return the full file size
+                if (outFile.length() == ins.available().toLong()) {
+                    logcat(LogPriority.VERBOSE) { "Skipping copy of asset file (exists same size): $filename" }
+                    continue
+                }
+                out = outFile.openOutputStream()
+                ins.copyTo(out)
+                logcat(LogPriority.WARN) { "Copied asset file: $filename" }
+            } catch (e: IOException) {
+                logcat(LogPriority.ERROR, e) { "Failed to copy asset file: $filename" }
+            } finally {
+                ins?.close()
+                out?.close()
+            }
+        }
+    }
+
+    private suspend inline fun ensureActive() {
+        if (!currentCoroutineContext().isActive) {
+            throw CancellationException()
+        }
+    }
+
+    companion object {
+        const val MPV_DIR = "mpv"
+        const val MPV_FONTS_DIR = "fonts"
+        const val MPV_SCRIPTS_DIR = "scripts"
+        const val MPV_SCRIPTS_OPTS_DIR = "script-opts"
+        const val MPV_SHADERS_DIR = "shaders"
+    }
+}

--- a/app/src/main/java/animiru/feature/mpvfiles/MpvConfig.kt
+++ b/app/src/main/java/animiru/feature/mpvfiles/MpvConfig.kt
@@ -48,47 +48,26 @@ class MpvConfig(
 
     private suspend fun copyUserFiles(mpvDir: UniFile) {
         // First, delete all present scripts
-        val scriptsDir = { mpvDir.createDirectory(MPV_SCRIPTS_DIR) }
-        val scriptOptsDir = { mpvDir.createDirectory(MPV_SCRIPTS_OPTS_DIR) }
-        val shadersDir = { mpvDir.createDirectory(MPV_SHADERS_DIR) }
-
-        scriptsDir()?.delete()
-        scriptOptsDir()?.delete()
-        shadersDir()?.delete()
+        val scriptsDir = deleteAndGet(mpvDir, MPV_SCRIPTS_DIR)
+        val scriptOptsDir = deleteAndGet(mpvDir, MPV_SCRIPTS_OPTS_DIR)
+        val shadersDir = deleteAndGet(mpvDir, MPV_SHADERS_DIR)
 
         // Then, copy the user files from the Aniyomi directory
         if (advancedPlayerPreferences.mpvUserFiles.get()) {
-            storageManager.getScriptsDirectory()?.listFiles()?.forEach { file ->
-                ensureActive()
-                val outFile = scriptsDir()?.createFile(file.name)
-                outFile?.let {
-                    file.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
-            storageManager.getScriptOptsDirectory()?.listFiles()?.forEach { file ->
-                ensureActive()
-                val outFile = scriptOptsDir()?.createFile(file.name)
-                outFile?.let {
-                    file.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
-            storageManager.getShadersDirectory()?.listFiles()?.forEach { file ->
-                ensureActive()
-                val outFile = shadersDir()?.createFile(file.name)
-                outFile?.let {
-                    file.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
+            copyDirectoryContents(storageManager.getScriptsDirectory(), scriptsDir)
+            copyDirectoryContents(storageManager.getScriptOptsDirectory(), scriptOptsDir)
+            copyDirectoryContents(storageManager.getShadersDirectory(), shadersDir)
         }
 
         val buttons = getCustomButtons.getAll()
         setupCustomButtons(buttons)
 
         // Copy over the bridge file
-        val luaFile = scriptsDir()?.createFile("aniyomi.lua")
-        val luaBridge = context.assets.open("aniyomi.lua")
-        luaFile?.openOutputStream()?.bufferedWriter()?.use { scriptLua ->
-            luaBridge.bufferedReader().use { scriptLua.write(it.readText()) }
+        val luaFile = scriptsDir.createFile("aniyomi.lua") ?: return
+        context.assets.open("aniyomi.lua").use { inputStream ->
+            luaFile.openOutputStream().use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
         }
     }
 
@@ -133,15 +112,8 @@ class MpvConfig(
     private suspend fun copyFontsDirectory(mpvDir: UniFile) {
         // TODO: I think this is a bad hack.
         //  We need to find a way to let MPV directly access our fonts directory.
-        val fontsDirectory = mpvDir.createDirectory(MPV_FONTS_DIR)!!
-
-        storageManager.getFontsDirectory()?.listFiles()?.forEach { font ->
-            ensureActive()
-            val outFile = fontsDirectory.createFile(font.name)
-            outFile?.let {
-                font.openInputStream().copyTo(it.openOutputStream())
-            }
-        }
+        val fontsDirectory = deleteAndGet(mpvDir, MPV_FONTS_DIR)
+        copyDirectoryContents(storageManager.getFontsDirectory(), fontsDirectory)
     }
 
     private fun copyAssets(mpvDir: UniFile) {
@@ -171,9 +143,23 @@ class MpvConfig(
         }
     }
 
-    private suspend inline fun ensureActive() {
-        if (!currentCoroutineContext().isActive) {
-            throw CancellationException()
+    private fun deleteAndGet(parent: UniFile, name: String): UniFile {
+        parent.createDirectory(name)?.delete()
+        return parent.createDirectory(name)!!
+    }
+
+    private suspend fun copyDirectoryContents(sourceDir: UniFile?, destDir: UniFile) {
+        sourceDir?.listFiles()?.forEach { file ->
+            if (!currentCoroutineContext().isActive) {
+                throw CancellationException()
+            }
+
+            val outFile = destDir.createFile(file.name) ?: return@forEach
+            file.openInputStream().use { input ->
+                outFile.openOutputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/animiru/feature/mpvfiles/MpvConfig.kt
+++ b/app/src/main/java/animiru/feature/mpvfiles/MpvConfig.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.isActive
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.custombutton.interactor.GetCustomButtons
+import tachiyomi.domain.custombutton.model.CustomButton
 import tachiyomi.domain.storage.service.StorageManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -24,6 +26,7 @@ class MpvConfig(
     private val context: Context,
     private val storageManager: StorageManager = Injekt.get(),
     private val advancedPlayerPreferences: AdvancedPlayerPreferences = Injekt.get(),
+    private val getCustomButtons: GetCustomButtons = Injekt.get(),
 ) {
     private val scope = CoroutineScope(Dispatchers.IO)
     private var copyJob: Job? = null
@@ -32,11 +35,15 @@ class MpvConfig(
         if (copyJob?.isActive == true) return
 
         copyJob = scope.launchIO {
-            val mpvDir = UniFile.fromFile(context.filesDir)!!.createDirectory(MPV_DIR)!!
+            val mpvDir = getMpvDir()
             copyUserFiles(mpvDir)
             copyFontsDirectory(mpvDir)
             copyAssets(mpvDir)
         }
+    }
+
+    private fun getMpvDir(): UniFile {
+        return UniFile.fromFile(context.filesDir)!!.createDirectory(MPV_DIR)!!
     }
 
     private suspend fun copyUserFiles(mpvDir: UniFile) {
@@ -74,11 +81,52 @@ class MpvConfig(
             }
         }
 
+        val buttons = getCustomButtons.getAll()
+        setupCustomButtons(buttons)
+
         // Copy over the bridge file
         val luaFile = scriptsDir()?.createFile("aniyomi.lua")
         val luaBridge = context.assets.open("aniyomi.lua")
         luaFile?.openOutputStream()?.bufferedWriter()?.use { scriptLua ->
             luaBridge.bufferedReader().use { scriptLua.write(it.readText()) }
+        }
+    }
+
+    fun setupCustomButtons(buttons: List<CustomButton>) {
+        val scriptsDir = getMpvDir().createDirectory(MPV_SCRIPTS_DIR)!!
+        val primaryButtonId = buttons.firstOrNull { it.isFavorite }?.id ?: 0L
+
+        val customButtonsContent = buildString {
+            appendLine(
+                """
+                    local lua_modules = mp.find_config_file('scripts')
+                    if lua_modules then
+                        package.path = package.path .. ';' .. lua_modules .. '/?.lua;' .. lua_modules .. '/?/init.lua;' .. '${scriptsDir.filePath}' .. '/?.lua'
+                    end
+                    local aniyomi = require 'aniyomi'
+                """.trimIndent(),
+            )
+
+            buttons.forEach { button ->
+                appendLine(
+                    """
+                        ${button.getButtonOnStartup(primaryButtonId)}
+                        function button${button.id}()
+                            ${button.getButtonContent(primaryButtonId)}
+                        end
+                        mp.register_script_message('call_button_${button.id}', button${button.id})
+                        function button${button.id}long()
+                            ${button.getButtonLongPressContent(primaryButtonId)}
+                        end
+                        mp.register_script_message('call_button_${button.id}_long', button${button.id}long)
+                    """.trimIndent(),
+                )
+            }
+        }
+
+        val file = scriptsDir.createFile("custombuttons.lua")
+        file?.openOutputStream()?.bufferedWriter()?.use {
+            it.write(customButtonsContent)
         }
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModel.kt
@@ -1,6 +1,7 @@
 package eu.kanade.presentation.more.settings.screen.player.custombutton
 
 import androidx.compose.runtime.Immutable
+import animiru.feature.mpvfiles.MpvConfig
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import dev.icerock.moko.resources.StringResource
@@ -8,9 +9,11 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.custombutton.interactor.CreateCustomButton
 import tachiyomi.domain.custombutton.interactor.DeleteCustomButton
 import tachiyomi.domain.custombutton.interactor.GetCustomButtons
@@ -30,6 +33,9 @@ class PlayerSettingsCustomButtonScreenModel(
     private val updateCustomButton: UpdateCustomButton = Injekt.get(),
     private val reorderCustomButton: ReorderCustomButton = Injekt.get(),
     private val toggleFavoriteCustomButton: ToggleFavoriteCustomButton = Injekt.get(),
+    // AM -->
+    private val mpvConfig: MpvConfig = Injekt.get(),
+    // <-- AM
 ) : StateScreenModel<CustomButtonScreenState>(CustomButtonScreenState.Loading) {
 
     private val _events: Channel<CustomButtonEvent> = Channel()
@@ -46,6 +52,16 @@ class PlayerSettingsCustomButtonScreenModel(
                     }
                 }
         }
+
+        // AM -->
+        screenModelScope.launchIO {
+            getCustomButtons.subscribeAll()
+                .distinctUntilChanged()
+                .collectLatest { customButtons ->
+                    mpvConfig.setupCustomButtons(customButtons)
+                }
+        }
+        // <-- AM
     }
 
     fun createCustomButton(name: String, content: String, longPressContent: String, onStartup: String) {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/PlayerSettingsEditorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/PlayerSettingsEditorScreenModel.kt
@@ -2,8 +2,10 @@ package eu.kanade.presentation.more.settings.screen.player.editor
 
 import android.content.Context
 import androidx.compose.runtime.Immutable
+import animiru.feature.mpvfiles.MpvConfig.Companion.MPV_DIR
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
+import com.hippo.unifile.UniFile
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.size
@@ -60,6 +62,17 @@ class PlayerSettingsEditorScreenModel(
                 return
             }
 
+        // AM -->
+        UniFile.fromFile(context.filesDir)
+            ?.createDirectory(MPV_DIR)
+            ?.createDirectory(selectedType.value.directoryName)
+            ?.createFile(fileName)
+            ?: run {
+                context.toast(context.stringResource(AYMR.strings.editor_create_error))
+                return
+            }
+        // <-- AM
+
         updateItems(selectedType.value)
     }
 
@@ -68,7 +81,14 @@ class PlayerSettingsEditorScreenModel(
             ?.createDirectory(selectedType.value.directoryName)
             ?.createFile(originalFile)
 
-        if (file?.renameTo(fileName) == true) {
+        // AM -->
+        val internalFile = UniFile.fromFile(context.filesDir)
+            ?.createDirectory(MPV_DIR)
+            ?.createDirectory(selectedType.value.directoryName)
+            ?.createFile(originalFile)
+        // <-- AM
+
+        if (file?.renameTo(fileName) == true && internalFile?.renameTo(fileName) == true) {
             updateItems(selectedType.value)
         } else {
             context.toast(context.stringResource(AYMR.strings.editor_rename_error))
@@ -80,7 +100,14 @@ class PlayerSettingsEditorScreenModel(
             ?.createDirectory(selectedType.value.directoryName)
             ?.findFile(name)
 
-        if (file?.delete() == true) {
+        // AM -->
+        val internalFile = UniFile.fromFile(context.filesDir)
+            ?.createDirectory(MPV_DIR)
+            ?.createDirectory(selectedType.value.directoryName)
+            ?.createFile(name)
+        // <-- AM
+
+        if (file?.delete() == true && internalFile?.delete() == true) {
             updateItems(selectedType.value)
         } else {
             context.toast(context.stringResource(AYMR.strings.editor_delete_error))

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/codeeditor/CodeEditScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/codeeditor/CodeEditScreenModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.TextFieldValue
+import animiru.feature.mpvfiles.MpvConfig.Companion.MPV_DIR
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import com.hippo.unifile.UniFile
@@ -110,6 +111,10 @@ class CodeEditScreenModel(
             context.toast(AYMR.strings.editor_save_error)
             return
         }
+        // AM -->
+        val internalFile = UniFile.fromFile(context.filesDir)!!.createDirectory(MPV_DIR)!!
+            .createFile(filePath)!!
+        // <-- AM
 
         val content = (mutableState.value as? CodeEditScreenState.Success)
             ?.content?.annotatedString?.text ?: kotlin.run {
@@ -121,6 +126,13 @@ class CodeEditScreenModel(
             file.openOutputStream()
                 .also { (it as? FileOutputStream)?.channel?.truncate(0) }
                 .use { it.write(content.toByteArray()) }
+
+            // AM -->
+            internalFile.openOutputStream()
+                .also { (it as? FileOutputStream)?.channel?.truncate(0) }
+                .use { it.write(content.toByteArray()) }
+            // <-- AM
+
             _hasModified.update { _ -> false }
             context.toast(context.stringResource(AYMR.strings.editor_save_success))
         } catch (e: Exception) {

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.di
 import android.app.Application
 import androidx.core.content.ContextCompat
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
+import animiru.feature.mpvfiles.MpvConfig
 import app.cash.sqldelight.db.SqlDriver
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteConfiguration
 import com.eygraber.sqldelight.androidx.driver.AndroidxSqliteDatabaseType
@@ -160,6 +161,7 @@ class AppModule(val app: Application) : InjektModule {
         // <-- AM (SYNC_DRIVE)
 
         // AM -->
+        addSingletonFactory { MpvConfig(app) }
         addSingletonFactory { AudioManager(app) }
         addSingletonFactory { BrightnessManager(app) }
         // <-- AM

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -53,6 +53,7 @@ import androidx.core.util.Consumer
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
 import androidx.lifecycle.lifecycleScope
+import animiru.feature.mpvfiles.MpvConfig
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.NavigatorDisposeBehavior
@@ -122,6 +123,7 @@ class MainActivity : BaseActivity() {
     private val preferences: BasePreferences by injectLazy()
 
     // AM -->
+    private val mpvConfig: MpvConfig by injectLazy()
     private val uiPreferences: UiPreferences by injectLazy()
     // <-- AM
 
@@ -522,6 +524,13 @@ class MainActivity : BaseActivity() {
         }
     }
     // <-- AY
+
+    // AM -->
+    override fun onResume() {
+        super.onResume()
+        mpvConfig.copyFiles()
+    }
+    // <-- AM
 
     companion object {
         const val INTENT_SEARCH = "eu.kanade.tachiyomi.SEARCH"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -226,7 +226,6 @@ class PlayerActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         setupPlayerMPV()
-        setupCustomButtons()
         setupPlayerAudio()
         setupMediaSession()
         setupPlayerOrientation()
@@ -467,58 +466,6 @@ class PlayerActivity : BaseActivity() {
         mpv.setOptionString("sub-use-margins", showBlackBars)
         mpv.addLogObserver(playerObserver)
         mpv.addObserver(playerObserver)
-    }
-
-    fun setupCustomButtons() {
-        viewModel.viewModelScope.launchIO {
-            val buttons = viewModel.getCustomButtons()
-            viewModel.setCustomButtons(buttons)
-
-            val scriptsDir = {
-                UniFile.fromFile(applicationContext.filesDir)
-                    ?.createDirectory(MPV_DIR)
-                    ?.createDirectory(MPV_SCRIPTS_DIR)
-            }
-
-            val primaryButtonId = viewModel.primaryButton.value?.id ?: 0L
-
-            val customButtonsContent = buildString {
-                appendLine(
-                    """
-                        local lua_modules = mp.find_config_file('scripts')
-                        if lua_modules then
-                            package.path = package.path .. ';' .. lua_modules .. '/?.lua;' .. lua_modules .. '/?/init.lua;' .. '${scriptsDir()!!.filePath}' .. '/?.lua'
-                        end
-                        local aniyomi = require 'aniyomi'
-                    """.trimIndent(),
-                )
-
-                buttons.forEach { button ->
-                    appendLine(
-                        """
-                            ${button.getButtonOnStartup(primaryButtonId)}
-                            function button${button.id}()
-                                ${button.getButtonContent(primaryButtonId)}
-                            end
-                            mp.register_script_message('call_button_${button.id}', button${button.id})
-                            function button${button.id}long()
-                                ${button.getButtonLongPressContent(primaryButtonId)}
-                            end
-                            mp.register_script_message('call_button_${button.id}_long', button${button.id}long)
-                        """.trimIndent(),
-                    )
-                }
-            }
-
-            val file = scriptsDir()?.createFile("custombuttons.lua")
-            file?.openOutputStream()?.bufferedWriter()?.use {
-                it.write(customButtonsContent)
-            }
-
-            file?.let {
-                mpv.command("load-script", it.filePath!!)
-            }
-        }
     }
 
     private fun setupPlayerAudio() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -30,7 +30,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
-import android.content.res.AssetManager
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.media.AudioManager
@@ -97,14 +96,10 @@ import tachiyomi.core.common.util.lang.launchNonCancellable
 import tachiyomi.core.common.util.lang.launchUI
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
-import tachiyomi.domain.storage.service.StorageManager
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.io.IOException
-import java.io.InputStream
-import java.io.OutputStream
 import kotlin.math.ceil
 import kotlin.math.floor
 
@@ -123,7 +118,6 @@ class PlayerActivity : BaseActivity() {
     private val audioPreferences: AudioPreferences = Injekt.get()
     private val advancedPlayerPreferences: AdvancedPlayerPreferences = Injekt.get()
     private val subtitlePreferences: SubtitlePreferences = Injekt.get()
-    private val storageManager: StorageManager = Injekt.get()
 
     // AM (DISCORD_RPC) -->
     // private val connectionPreferences: ConnectionPreferences = Injekt.get()
@@ -457,6 +451,7 @@ class PlayerActivity : BaseActivity() {
 
     private fun setupPlayerMPV() {
         val mpvDir = UniFile.fromFile(applicationContext.filesDir)!!.createDirectory(MPV_DIR)!!
+        val fontsDirectory = mpvDir.createDirectory(MPV_FONTS_DIR)!!
 
         val mpvConfFile = mpvDir.createFile("mpv.conf")!!
         advancedPlayerPreferences.mpvConf.get().let { mpvConfFile.writeText(it) }
@@ -464,100 +459,14 @@ class PlayerActivity : BaseActivity() {
         advancedPlayerPreferences.mpvInput.get().let { mpvInputFile.writeText(it) }
 
         player.init(mpv)
-        copyUserFiles(mpvDir)
-        copyAssets(mpvDir)
-        copyFontsDirectory(mpvDir)
 
+        mpv.setPropertyString("sub-fonts-dir", fontsDirectory.filePath!!)
+        mpv.setPropertyString("osd-fonts-dir", fontsDirectory.filePath!!)
         val showBlackBars = if (subtitlePreferences.subtitleBlackBars.get()) "yes" else "no"
         mpv.setOptionString("sub-ass-force-margins", showBlackBars)
         mpv.setOptionString("sub-use-margins", showBlackBars)
         mpv.addLogObserver(playerObserver)
         mpv.addObserver(playerObserver)
-    }
-
-    private fun copyUserFiles(mpvDir: UniFile) {
-        // First, delete all present scripts
-        val scriptsDir = { mpvDir.createDirectory(MPV_SCRIPTS_DIR) }
-        val scriptOptsDir = { mpvDir.createDirectory(MPV_SCRIPTS_OPTS_DIR) }
-        val shadersDir = { mpvDir.createDirectory(MPV_SHADERS_DIR) }
-
-        scriptsDir()?.delete()
-        scriptOptsDir()?.delete()
-        shadersDir()?.delete()
-
-        // Then, copy the user files from the Aniyomi directory
-        if (advancedPlayerPreferences.mpvUserFiles.get()) {
-            storageManager.getScriptsDirectory()?.listFiles()?.forEach { file ->
-                val outFile = scriptsDir()?.createFile(file.name)
-                outFile?.let {
-                    file.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
-            storageManager.getScriptOptsDirectory()?.listFiles()?.forEach { file ->
-                val outFile = scriptOptsDir()?.createFile(file.name)
-                outFile?.let {
-                    file.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
-            storageManager.getShadersDirectory()?.listFiles()?.forEach { file ->
-                val outFile = shadersDir()?.createFile(file.name)
-                outFile?.let {
-                    file.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
-        }
-
-        // Copy over the bridge file
-        val luaFile = scriptsDir()?.createFile("aniyomi.lua")
-        val luaBridge = assets.open("aniyomi.lua")
-        luaFile?.openOutputStream()?.bufferedWriter()?.use { scriptLua ->
-            luaBridge.bufferedReader().use { scriptLua.write(it.readText()) }
-        }
-    }
-
-    private fun copyAssets(mpvDir: UniFile) {
-        val assetManager = this.assets
-        val files = arrayOf("subfont.ttf", "cacert.pem")
-        for (filename in files) {
-            var ins: InputStream? = null
-            var out: OutputStream? = null
-            try {
-                ins = assetManager.open(filename, AssetManager.ACCESS_STREAMING)
-                val outFile = mpvDir.createFile(filename)!!
-                // Note that .available() officially returns an *estimated* number of bytes available
-                // this is only true for generic streams, asset streams return the full file size
-                if (outFile.length() == ins.available().toLong()) {
-                    logcat(LogPriority.VERBOSE) { "Skipping copy of asset file (exists same size): $filename" }
-                    continue
-                }
-                out = outFile.openOutputStream()
-                ins.copyTo(out)
-                logcat(LogPriority.WARN) { "Copied asset file: $filename" }
-            } catch (e: IOException) {
-                logcat(LogPriority.ERROR, e) { "Failed to copy asset file: $filename" }
-            } finally {
-                ins?.close()
-                out?.close()
-            }
-        }
-    }
-
-    private fun copyFontsDirectory(mpvDir: UniFile) {
-        // TODO: I think this is a bad hack.
-        //  We need to find a way to let MPV directly access our fonts directory.
-        lifecycleScope.launchIO {
-            val fontsDirectory = mpvDir.createDirectory(MPV_FONTS_DIR)!!
-
-            storageManager.getFontsDirectory()?.listFiles()?.forEach { font ->
-                val outFile = fontsDirectory.createFile(font.name)
-                outFile?.let {
-                    font.openInputStream().copyTo(it.openOutputStream())
-                }
-            }
-
-            mpv.setPropertyString("sub-fonts-dir", fontsDirectory.filePath!!)
-            mpv.setPropertyString("osd-fonts-dir", fontsDirectory.filePath!!)
-        }
     }
 
     fun setupCustomButtons() {
@@ -574,7 +483,7 @@ class PlayerActivity : BaseActivity() {
             val primaryButtonId = viewModel.primaryButton.value?.id ?: 0L
 
             val customButtonsContent = buildString {
-                append(
+                appendLine(
                     """
                         local lua_modules = mp.find_config_file('scripts')
                         if lua_modules then
@@ -585,7 +494,7 @@ class PlayerActivity : BaseActivity() {
                 )
 
                 buttons.forEach { button ->
-                    append(
+                    appendLine(
                         """
                             ${button.getButtonOnStartup(primaryButtonId)}
                             function button${button.id}()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -357,11 +357,7 @@ class PlayerViewModel @JvmOverloads constructor(
         }
     }
 
-    suspend fun getCustomButtons(): List<CustomButton> {
-        return getCustomButtons.getAll()
-    }
-
-    fun setCustomButtons(buttons: List<CustomButton>) {
+    private fun setCustomButtons(buttons: List<CustomButton>) {
         _customButtons.update { _ -> buttons.toPersistentList() }
         buttons.firstOrNull { it.isFavorite }?.let {
             _primaryButton.update { _ -> it }
@@ -1260,6 +1256,9 @@ class PlayerViewModel @JvmOverloads constructor(
                 animeTitle.update { _ -> anime.title }
                 sourceManager.isInitialized.first { it }
                 episodeId = initialEpisodeId
+
+                val buttons = getCustomButtons.getAll()
+                setCustomButtons(buttons)
 
                 checkTrackers(anime)
 


### PR DESCRIPTION
The problem:
Copying over files can take a decent amount of time which is currently spent before playing a video. Having to wait for everything to copy over isn't ideal. Currently this is done _after_ mpv is initialized, so you need to reopen the player once more to see the changes.

The solution:
Copy over everything when the app is in foreground instead. Then there's no need to wait for files to be copied over when opening the player.

Potential TODOs:
- [x] Do something similar for custom buttons, although that task takes <10ms