### PR TITLE
Fix being able to add unsupported trackers to entries with seasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Fixed
 - Bump mpv ([@Secozzi](https://github.com/Secozzi)) ([#144](https://github.com/quickdesh/Animiru/pull/144))
+- Fix being able to add unsupported trackers to seasons ([@Secozzi](https://github.com/Secozzi)) ([#147](https://github.com/quickdesh/Animiru/pull/147))
 
 ## [v0.19.7.0] - 2026-03-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Fixed
 - Bump mpv ([@Secozzi](https://github.com/Secozzi)) ([#144](https://github.com/quickdesh/Animiru/pull/144))
-- Fix being able to add unsupported trackers to seasons ([@Secozzi](https://github.com/Secozzi)) ([#147](https://github.com/quickdesh/Animiru/pull/147))
+- Fix being able to add unsupported trackers to entries with seasons ([@Secozzi](https://github.com/Secozzi)) ([#147](https://github.com/quickdesh/Animiru/pull/147))
 
 ## [v0.19.7.0] - 2026-03-30
 ### Added

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/anime/track/TrackInfoDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/anime/track/TrackInfoDialog.kt
@@ -280,6 +280,10 @@ data class TrackInfoDialogHomeScreen(
                 .map { service -> TrackItem(find { it.trackerId == service.id }, service) }
                 // Show only if the service supports this anime's source
                 .filter { (it.tracker as? EnhancedTracker)?.accept(source) ?: true }
+                // AM -->
+                // Only show enhanced trackers for seasons for now
+                .filter { !isSeason || it.tracker is EnhancedTracker }
+            // <-- AM
         }
 
         @Immutable


### PR DESCRIPTION
For now, the only reason entries with seasons can be tracked at all is to apply tracking and syncing to each seasons, which is something only enhanced trackers can currently do.