### PR TITLE
Allow options in mpv.conf to override options set by `AniyomiMPVView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - `Other` - for technical stuff.
 
 ## [Unreleased]
+### Improved
+- Allow options in mpv.conf to override options set by `AniyomiMPVView` ([@Secozzi](https://github.com/Secozzi)) ([#151](https://github.com/quickdesh/Animiru/pull/151))
+
 ### Fixed
 - Fixed player crash when running out of available videos ([@Secozzi](https://github.com/Secozzi)) ([#150](https://github.com/quickdesh/Animiru/pull/150))
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/AniyomiMPVView.kt
@@ -49,6 +49,17 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet?) : BaseMPVView(
 
     var isExiting = false
 
+    private val optionNameRegex = Regex("""^(?:--)?([\w-]+)(?:=|$)""", RegexOption.MULTILINE)
+    private val mpvOptionNames = optionNameRegex.findAll(advancedPreferences.mpvConf.get()).map {
+        it.groupValues[1].removePrefix("no-")
+    }.toSet()
+
+    // Set mpv option unless it's present in mpv.conf
+    private fun setSafeOptionString(name: String, value: String) {
+        if (name in mpvOptionNames) return
+        mpv?.setOptionString(name, value)
+    }
+
     /**
      * Returns the video aspect ratio. Rotation is taken into account.
      */
@@ -63,7 +74,7 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet?) : BaseMPVView(
         this.mpv = mpvInst
         setVo(if (decoderPreferences.gpuNext.get()) "gpu-next" else "gpu")
         mpv?.setPropertyBoolean("pause", true)
-        mpv?.setOptionString("profile", "fast")
+        setSafeOptionString("profile", "fast")
         mpv?.setOptionString("hwdec", if (decoderPreferences.tryHWDecoding.get()) "auto" else "no")
 
         if (decoderPreferences.useYUV420P.get()) {
@@ -75,8 +86,8 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet?) : BaseMPVView(
 
         mpv?.setOptionString("idle", "yes")
         mpv?.setOptionString("ytdl", "no")
-        mpv?.setOptionString("tls-verify", "yes")
-        mpv?.setOptionString("tls-ca-file", "${context.filesDir.path}/${PlayerActivity.MPV_DIR}/cacert.pem")
+        setSafeOptionString("tls-verify", "yes")
+        setSafeOptionString("tls-ca-file", "${context.filesDir.path}/${PlayerActivity.MPV_DIR}/cacert.pem")
 
         // We handle selecting this in the viewmodel
         mpv?.setOptionString("sid", "no")
@@ -84,8 +95,8 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet?) : BaseMPVView(
 
         // Limit demuxer cache since the defaults are too high for mobile devices
         val cacheMegs = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) 64 else 32
-        mpv?.setOptionString("demuxer-max-bytes", "${cacheMegs * 1024 * 1024}")
-        mpv?.setOptionString("demuxer-max-back-bytes", "${cacheMegs * 1024 * 1024}")
+        setSafeOptionString("demuxer-max-bytes", "${cacheMegs * 1024 * 1024}")
+        setSafeOptionString("demuxer-max-back-bytes", "${cacheMegs * 1024 * 1024}")
 
         val screenshotDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
         screenshotDir.mkdirs()
@@ -97,7 +108,7 @@ class AniyomiMPVView(context: Context, attributes: AttributeSet?) : BaseMPVView(
 
         mpv?.setOptionString("speed", playerPreferences.playerSpeed.get().toString())
         // workaround for <https://github.com/mpv-player/mpv/issues/14651>
-        mpv?.setOptionString("vd-lavc-film-grain", "cpu")
+        setSafeOptionString("vd-lavc-film-grain", "cpu")
 
         postInitOptions()
         setupSubtitlesOptions()


### PR DESCRIPTION
Some options may be desirable to change via mpv.conf, but currently it's impossible to change them since `AniyomiMPVView` sets them anyways. Telling `AniyomiMPVView` to not set options that are already present in mpv.conf fixes this. This should not be done for every option, since they're either set via preferences or break assumptions that other parts of the app relies on.